### PR TITLE
Fix graspDSR agent compilation errors

### DIFF
--- a/components/graspDSR/src/CMakeListsSpecific.txt
+++ b/components/graspDSR/src/CMakeListsSpecific.txt
@@ -4,6 +4,9 @@ INCLUDE( $ENV{ROBOCOMP}/cmake/modules/opencv4.cmake )
 SET ( SOURCES
   specificworker.cpp
   specificmonitor.cpp
+  $ENV{ROBOCOMP}/classes/dsr/api/dsr_api.cpp
+  $ENV{ROBOCOMP}/classes/dsr/core/types/crdt_types.cpp
+  $ENV{ROBOCOMP}/classes/dsr/core/types/user_types.cpp
   $ENV{ROBOCOMP}/classes/dsr/core/rtps/dsrpublisher.cpp
   $ENV{ROBOCOMP}/classes/dsr/core/rtps/dsrsubscriber.cpp
   $ENV{ROBOCOMP}/classes/dsr/core/rtps/dsrparticipant.cpp
@@ -28,9 +31,15 @@ SET ( HEADERS
   specificmonitor.h
   $ENV{ROBOCOMP}/classes/dsr/api/dsr_api.h
   $ENV{ROBOCOMP}/classes/dsr/gui/dsr_gui.h
+  $ENV{ROBOCOMP}/classes/graph-related-classes/CRDT.h
+  $ENV{ROBOCOMP}/classes/graph-related-classes/CRDT_graphviewer.h
+  $ENV{ROBOCOMP}/classes/graph-related-classes/CRDT_graph.h
+  $ENV{ROBOCOMP}/classes/graph-related-classes/CRDT_graphnode.h
+  $ENV{ROBOCOMP}/classes/graph-related-classes/CRDT_graphedge.h
 )
 
 set(CMAKE_CXX_STANDARD 17)
 
-add_definitions(-g  -fmax-errors=1 -std=c++2a )
-SET (LIBS ${LIBS}   fastcdr fastrtps osgDB)
+SET(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-fmax-errors=5" )
+add_definitions(-Og  -fmax-errors=1 -std=c++2a )
+SET(SPECIFIC_LIBS  fastcdr fastrtps osgDB)

--- a/components/graspDSR/src/specificworker.cpp
+++ b/components/graspDSR/src/specificworker.cpp
@@ -205,7 +205,7 @@ RoboCompCameraRGBDSimple::TDepth SpecificWorker::get_depth_from_G()
         RoboCompCameraRGBDSimple::TDepth depth;
         try
         {
-            auto depth_data = G->get_depth_image(cam.value());
+            auto depth_data = G->get_attrib_by_name<img_depth_att>(cam.value());
             const auto width = G->get_attrib_by_name<depth_width>(cam.value());
             const auto height = G->get_attrib_by_name<depth_height>(cam.value());
             const auto cam_id = G->get_attrib_by_name<depth_cameraID>(cam.value());
@@ -215,7 +215,7 @@ RoboCompCameraRGBDSimple::TDepth SpecificWorker::get_depth_from_G()
             const auto alivetime = G->get_attrib_by_name<rgb_alivetime>(cam.value());
 
             // assign attributes to RoboCompCameraRGBDSimple::TDepth
-            depth.depth = depth_data.value().get();
+            depth.depth = depth_data.value();
             depth.width = width.value();
             depth.height = height.value();
             depth.cameraID = cam_id.value();


### PR DESCRIPTION
This PR contains :
- Complete headers and source files inclusion in graspDSR.
- Usage of get_attrib_by_name() to get depth until the issue with get_depth_image() is resolved.