### PR TITLE
Add custom QT widget for image display and object selection in graspDSR agent

### DIFF
--- a/components/graspDSR/etc/config
+++ b/components/graspDSR/etc/config
@@ -14,9 +14,6 @@ graph_view = true
 
 InnerModelPath = innermodel.xml
 
-# Grasping objects
-grasp_object = glass_1
-
 # Ice configuration
 Ice.MessageSizeMax=20004800
 

--- a/components/graspDSR/src/CMakeLists.txt
+++ b/components/graspDSR/src/CMakeLists.txt
@@ -38,7 +38,7 @@ ROBOCOMP_IDSL_TO_ICE( CommonBehavior CameraRGBDSimple DSRGetID ObjectPoseEstimat
 ROBOCOMP_ICE_TO_SRC( CommonBehavior CameraRGBDSimple DSRGetID ObjectPoseEstimationRGBD DSRGetID)
 SET (EXECUTABLE_OUTPUT_PATH ${RC_COMPONENT_DEVEL_PATH}/bin)
 
-QT_WRAP_UI( UI_HEADERS mainUI.ui )
+QT_WRAP_UI( UI_HEADERS mainUI.ui localUI.ui )
 
 # Specify construction and link process
 ADD_EXECUTABLE( graspDSR ${SOURCES} ${MOC_SOURCES} ${RC_SOURCES} ${UI_HEADERS} )

--- a/components/graspDSR/src/CMakeListsSpecific.txt
+++ b/components/graspDSR/src/CMakeListsSpecific.txt
@@ -23,6 +23,7 @@ SET ( SOURCES
   $ENV{ROBOCOMP}/classes/dsr/gui/viewers/graph_viewer/graph_edge.cpp
   $ENV{ROBOCOMP}/classes/dsr/gui/viewers/tree_viewer/tree_viewer.cpp
   $ENV{ROBOCOMP}/classes/dsr/gui/viewers/_abstract_graphic_view.cpp
+  custom_widget.h
 )
 
 # Headers set

--- a/components/graspDSR/src/custom_widget.h
+++ b/components/graspDSR/src/custom_widget.h
@@ -1,0 +1,55 @@
+/*
+ *    Copyright (C) 2020 by YOUR NAME HERE
+ *
+ *    This file is part of RoboComp
+ *
+ *    RoboComp is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    RoboComp is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with RoboComp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+	\brief
+	@author authorname
+*/
+
+
+
+#ifndef CUSTOMWIDGET_H
+#define CUSTOMWIDGET_H
+
+#if Qt5_FOUND
+	#include <QtWidgets>
+#else
+	#include <QtGui>
+#endif
+
+#include <ui_localUI.h>
+
+
+class Custom_widget : public QWidget, public Ui_local_guiDlg
+{
+Q_OBJECT
+public:
+    Custom_widget() : Ui_local_guiDlg()
+    {
+        setupUi(this);
+    }
+	~Custom_widget()
+    {
+
+    }
+
+
+
+};
+#endif

--- a/components/graspDSR/src/localUI.ui
+++ b/components/graspDSR/src/localUI.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="rgb_image_tab">
       <attribute name="title">
@@ -58,6 +58,9 @@
        </property>
        <property name="text">
         <string>glass_1</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
        </property>
        <attribute name="buttonGroup">
         <string notr="true">object_sel_group</string>

--- a/components/graspDSR/src/localUI.ui
+++ b/components/graspDSR/src/localUI.ui
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>local_guiDlg</class>
+ <widget class="QWidget" name="local_guiDlg">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>716</width>
+    <height>498</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="rgb_image_tab">
+      <attribute name="title">
+       <string>RGB Image</string>
+      </attribute>
+      <widget class="QLabel" name="rgb_image">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>671</width>
+         <height>431</height>
+        </rect>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>320</width>
+         <height>240</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Image</string>
+       </property>
+      </widget>
+     </widget>
+     <widget class="QWidget" name="object_sel_tab">
+      <attribute name="title">
+       <string>Object Selection</string>
+      </attribute>
+      <widget class="QRadioButton" name="obj_sel_radio_1">
+       <property name="geometry">
+        <rect>
+         <x>40</x>
+         <y>50</y>
+         <width>112</width>
+         <height>23</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>glass_1</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">object_sel_group</string>
+       </attribute>
+      </widget>
+      <widget class="QRadioButton" name="obj_sel_radio_2">
+       <property name="geometry">
+        <rect>
+         <x>40</x>
+         <y>80</y>
+         <width>112</width>
+         <height>23</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>cup_1</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">object_sel_group</string>
+       </attribute>
+      </widget>
+      <widget class="QRadioButton" name="obj_sel_radio_3">
+       <property name="geometry">
+        <rect>
+         <x>40</x>
+         <y>110</y>
+         <width>112</width>
+         <height>23</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>can_1</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">object_sel_group</string>
+       </attribute>
+      </widget>
+      <widget class="QRadioButton" name="obj_sel_radio_4">
+       <property name="geometry">
+        <rect>
+         <x>40</x>
+         <y>140</y>
+         <width>112</width>
+         <height>23</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>box_1</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">object_sel_group</string>
+       </attribute>
+      </widget>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+ <buttongroups>
+  <buttongroup name="object_sel_group">
+   <property name="exclusive">
+    <bool>true</bool>
+   </property>
+  </buttongroup>
+ </buttongroups>
+</ui>

--- a/components/graspDSR/src/specificmonitor.cpp
+++ b/components/graspDSR/src/specificmonitor.cpp
@@ -104,9 +104,6 @@ void SpecificMonitor::readConfig(RoboCompCommonBehavior::ParameterList &params )
 	params["2d_view"] = aux;
 	configGetString( "","3d_view", aux.value, "none");
 	params["3d_view"] = aux;
-
-	configGetString( "","grasp_object", aux.value,"");
-    params["grasp_object"] = aux;
 }
 
 //Check parameters and transform them to worker structure

--- a/components/graspDSR/src/specificworker.cpp
+++ b/components/graspDSR/src/specificworker.cpp
@@ -45,7 +45,6 @@ bool SpecificWorker::setParams(RoboCompCommonBehavior::ParameterList params)
     graph_view = params["graph_view"].value == "true";
     qscene_2d_view = params["2d_view"].value == "true";
     osg_3d_view = params["3d_view"].value == "true";
-    grasp_object = params["grasp_object"].value;
 
     return true;
 }
@@ -101,8 +100,18 @@ void SpecificWorker::compute()
     // read RGBD image from graph
     RoboCompCameraRGBDSimple::TImage rgb = get_rgb_from_G();
     RoboCompCameraRGBDSimple::TDepth depth = get_depth_from_G();
+
     // cast RGB image to OpenCV Mat
     cv::Mat img = cv::Mat(rgb.height, rgb.width, CV_8UC3, &rgb.image[0]);
+
+    // get grasp object from QT widget
+    QAbstractButton* sel_button = custom_widget.object_sel_group->checkedButton();
+    if (sel_button)
+    {
+        QString button_text = sel_button->text();
+        grasp_object = button_text.toStdString();
+    }
+
     // call pose estimation on RGBD and receive estimated poses
     RoboCompObjectPoseEstimationRGBD::PoseType poses;
     try
@@ -113,6 +122,7 @@ void SpecificWorker::compute()
     {
         std::cout << e << " No RoboCompPoseEstimation component found" << std::endl;
     }
+
     if (poses.size() != 0)
     {
         // display RGB image on QT widget

--- a/components/graspDSR/src/specificworker.cpp
+++ b/components/graspDSR/src/specificworker.cpp
@@ -87,6 +87,8 @@ void SpecificWorker::initialize(int period)
             current_opts = current_opts | opts::osg;
         }
         graph_viewer = std::make_unique<DSR::DSRViewer>(this, G, current_opts, main);
+        graph_viewer->add_custom_widget_to_dock("Grasping", &custom_widget); // custom_widget
+
         setWindowTitle(QString::fromStdString(agent_name + "-") + QString::number(agent_id));
 
         this->Period = period;

--- a/components/graspDSR/src/specificworker.cpp
+++ b/components/graspDSR/src/specificworker.cpp
@@ -101,6 +101,8 @@ void SpecificWorker::compute()
     // read RGBD image from graph
     RoboCompCameraRGBDSimple::TImage rgb = get_rgb_from_G();
     RoboCompCameraRGBDSimple::TDepth depth = get_depth_from_G();
+    // cast RGB image to OpenCV Mat
+    cv::Mat img = cv::Mat(rgb.height, rgb.width, CV_8UC3, &rgb.image[0]);
     // call pose estimation on RGBD and receive estimated poses
     RoboCompObjectPoseEstimationRGBD::PoseType poses;
     try
@@ -113,6 +115,9 @@ void SpecificWorker::compute()
     }
     if (poses.size() != 0)
     {
+        // display RGB image on QT widget
+        show_image(img, poses);
+
         // inject estimated poses into graph
         this->inject_estimated_poses(poses);
 
@@ -354,6 +359,17 @@ vector<float> SpecificWorker::interpolate_trans(vector<float> src, vector<float>
     }
 
     return interp_trans;
+}
+
+/////////////////////////////////////////////////////////////////
+//                     Display utilities
+/////////////////////////////////////////////////////////////////
+
+void SpecificWorker::show_image(cv::Mat &img, RoboCompObjectPoseEstimationRGBD::PoseType poses)
+{
+    // TODO : draw the DNN-estimated poses on the displayed image
+    auto pix = QPixmap::fromImage(QImage(img.data, img.cols, img.rows, QImage::Format_RGB888));
+    custom_widget.rgb_image->setPixmap(pix);
 }
 
 int SpecificWorker::startup_check()

--- a/components/graspDSR/src/specificworker.h
+++ b/components/graspDSR/src/specificworker.h
@@ -81,6 +81,9 @@ private:
 
 	// G injection utilities
 	void inject_estimated_poses(RoboCompObjectPoseEstimationRGBD::PoseType poses);
+
+	// Display utilities
+    void show_image(cv::Mat &img, RoboCompObjectPoseEstimationRGBD::PoseType poses);
 };
 
 #endif

--- a/components/graspDSR/src/specificworker.h
+++ b/components/graspDSR/src/specificworker.h
@@ -49,9 +49,8 @@ private:
 	// DSR graph
 	std::shared_ptr<DSR::DSRGraph> G;
 
-	//DSR params
+	// DSR params
 	std::string agent_name;
-	std::string grasp_object;
 	
 	int agent_id;
 
@@ -70,6 +69,9 @@ private:
     Custom_widget custom_widget;
 
 	// Pose Estimation & Grasping
+
+	// Grasp object
+    std::string grasp_object;
 
 	// Geometry utilities
 	vector<float> quat_to_euler(vector<float> quat);

--- a/components/graspDSR/src/specificworker.h
+++ b/components/graspDSR/src/specificworker.h
@@ -26,6 +26,7 @@
 #define SPECIFICWORKER_H
 
 #include <genericworker.h>
+#include <custom_widget.h>
 #include "dsr/api/dsr_api.h"
 #include "dsr/gui/dsr_gui.h"
 #include <opencv2/core.hpp>
@@ -64,6 +65,9 @@ private:
 	QHBoxLayout mainLayout;
 	QWidget window;
 	bool startup_check_flag;
+
+    // Local widget
+    Custom_widget custom_widget;
 
 	// Pose Estimation & Grasping
 


### PR DESCRIPTION
This PR contains :
- Addition of custom QT widget in graspDSR agent.
- RGB image display in QT widget.
- Grasp object selection from UI instead of config file.