### PR TITLE
Update target planning in graspDSR based on new changes in G

### DIFF
--- a/components/graspDSR/src/specificworker.cpp
+++ b/components/graspDSR/src/specificworker.cpp
@@ -134,8 +134,8 @@ void SpecificWorker::compute()
         this->inject_estimated_poses(poses);
 
         // get arm target and required object poses
-        auto world_node = G->get_node("world");
-        auto arm_id = G->get_id_from_name("viriato_arm_target");
+        auto world_node = G->get_node(world_name);
+        auto arm_id = G->get_id_from_name(viriato_left_arm_tip_name);
         auto object_id = G->get_id_from_name(grasp_object);
         
         auto world_arm_edge = G->get_edge_RT(world_node.value(), arm_id.value());
@@ -174,7 +174,7 @@ void SpecificWorker::compute()
 RoboCompCameraRGBDSimple::TImage SpecificWorker::get_rgb_from_G()
 {
     // get head camera node
-    auto cam = G->get_node("viriato_head_camera_sensor");
+    auto cam = G->get_node(viriato_head_camera_name);
     if (cam.has_value())
     {
         // read RGB data attributes from graph 
@@ -217,7 +217,7 @@ RoboCompCameraRGBDSimple::TImage SpecificWorker::get_rgb_from_G()
 RoboCompCameraRGBDSimple::TDepth SpecificWorker::get_depth_from_G()
 {
     // get head camera node
-    auto cam = G->get_node("viriato_head_camera_sensor");
+    auto cam = G->get_node(viriato_head_camera_name);
     if (cam.has_value())
     {
         // read depth data attributes from graph
@@ -260,7 +260,7 @@ RoboCompCameraRGBDSimple::TDepth SpecificWorker::get_depth_from_G()
 std::vector<std::vector<float>> SpecificWorker::get_camera_intrinsics()
 {
     // get head camera node
-    auto cam = G->get_node("viriato_head_camera_sensor");
+    auto cam = G->get_node(viriato_head_camera_name);
     if (cam.has_value())
     {
         try
@@ -300,7 +300,7 @@ void SpecificWorker::inject_estimated_poses(RoboCompObjectPoseEstimationRGBD::Po
     // get innermodel sub-API
     auto innermodel = G->get_inner_eigen_api();
     // get a copy of world node
-    auto world = G->get_node("world");
+    auto world = G->get_node(world_name);
     // loop over each estimated object pose
     for (auto pose : poses)
     {
@@ -313,7 +313,7 @@ void SpecificWorker::inject_estimated_poses(RoboCompObjectPoseEstimationRGBD::Po
             // re-project estimated poses into world coordinates
             Eigen::Matrix<double, 6, 1> orig_point;
             orig_point << pose.x, pose.y, pose.z, angles.at(0), angles.at(1), angles.at(2);
-            auto final_pose = innermodel->transform_axis("world", orig_point, "camera_pose");
+            auto final_pose = innermodel->transform_axis(world_name, orig_point, viriato_head_camera_name);
 
             // get object node id (if exists)
             auto id = G->get_id_from_name(pose.objectname);

--- a/components/graspDSR/src/specificworker.cpp
+++ b/components/graspDSR/src/specificworker.cpp
@@ -115,9 +115,11 @@ void SpecificWorker::compute()
     {
         QString button_text = sel_button->text();
         grasp_object = button_text.toStdString();
+        std::cout << "Object '" << grasp_object << "' is selected to be the target" << std::endl;
     }
 
     // call pose estimation on RGBD and receive estimated poses
+    std::cout << "Obtain DNN-estimated poses" << std::endl;
     RoboCompObjectPoseEstimationRGBD::PoseType poses;
     try
     {
@@ -134,13 +136,18 @@ void SpecificWorker::compute()
         show_image(img, poses);
 
         // inject estimated poses into graph
+        std::cout << "Inject DNN-estimated poses into G" << std::endl;
         this->inject_estimated_poses(poses);
 
-        // get arm target and required object poses
+        // plan dummy targets for the arm to follow
+        std::cout << "Plan arm's dummy targets" << std::endl;
+
+        // get world, grasp object and arm nodes
         auto world_node = G->get_node(world_name);
         auto tip_node = G->get_node(viriato_left_arm_tip_name);
         auto object_node = G->get_node(grasp_object);
 
+        // get required nodes poses
         auto object_pose = innermodel->transform_axis(world_name, grasp_object);
         auto tip_pose = innermodel->transform_axis(world_name, viriato_left_arm_tip_name);
 
@@ -307,6 +314,8 @@ void SpecificWorker::inject_estimated_poses(RoboCompObjectPoseEstimationRGBD::Po
     {
         if (pose.objectname.compare(grasp_object) == 0)
         {
+            std::cout << "Target object '" << pose.objectname << "' detected" << std::endl;
+
             // convert quaternions into euler angles
             vector<float> quat{pose.qx, pose.qy, pose.qz, pose.qw};
             vector<float> angles = this->quat_to_euler(quat);

--- a/components/graspDSR/src/specificworker.h
+++ b/components/graspDSR/src/specificworker.h
@@ -53,6 +53,7 @@ public slots:
 private:
 	// DSR graph
 	std::shared_ptr<DSR::DSRGraph> G;
+    std::shared_ptr<DSR::InnerEigenAPI> inner_eigen;
 
 	// DSR params
 	std::string agent_name;
@@ -92,6 +93,7 @@ private:
 
 	// G injection utilities
 	void inject_estimated_poses(RoboCompObjectPoseEstimationRGBD::PoseType poses);
+    void update_node_slot(const std::int32_t id, const std::string &type);
 
 	// IO utilities
     std::map<std::string,std::vector<std::vector<float>>> read_pcl_from_file();

--- a/components/graspDSR/src/specificworker.h
+++ b/components/graspDSR/src/specificworker.h
@@ -35,6 +35,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <Eigen/Dense>
+#include "../../../etc/viriato_graph_names.h"
 
 class SpecificWorker : public GenericWorker
 {


### PR DESCRIPTION
This PR contains :
- Usage of nodes names from C++ header in graspDSR.
- Update tip pose attribute instead of RT edge in graspDSR.
- More logs to graspDSR.
- Usage of callback function to update attributes based on node update signal.