### PR TITLE
removes usage of abstract class directly

### DIFF
--- a/robots_pyrep/viriatoPyrep/src/specificworker.py
+++ b/robots_pyrep/viriatoPyrep/src/specificworker.py
@@ -56,9 +56,9 @@ class SpecificWorker(GenericWorker):
         
         #self.robot = Viriato()
         self.robot = YouBot()
-        self.robot_object = Object("youBot")
-        self.robot_left_arm = Object("viriato_left_arm")
-        self.robot_left_arm_tip = Object("viriato_left_arm_tip")
+        self.robot_object = Shape("youBot")
+        self.robot_left_arm = Shape("viriato_left_arm")
+        self.robot_left_arm_tip = Dummy("viriato_left_arm_tip")
 
         self.cameras = {}
         # cam = VisionSensor("camera_1_rgbd_sensor")


### PR DESCRIPTION
There exists usage of Object class directly instead this commit use of inherited shape and dummy classes. @pbustos @orensbruli 
solves this issue
```
Traceback (most recent call last):
File "src/viriatoPyrep.py", line 230, in <module>
worker.setParams(parameters)
File "/home/pawan/robocomp/components/dsr-graph/robots_pyrep/viriatoPyrep/src/specificworker.py", line 59, in setParams
self.robot_object = Object("youBot")
File "/home/pawan/.local/lib/python3.6/site-packages/pyrep/objects/object.py", line 25, in init
assert_type = self._get_requested_type()
File "/home/pawan/.local/lib/python3.6/site-packages/pyrep/objects/object.py", line 88, in _get_requested_type
raise NotImplementedError('Must be overridden.')
NotImplementedError: Must be overridden.
SpecificWorker destructor

Error: signal 11:
```